### PR TITLE
Fix the problem with compilation on Android/Arm

### DIFF
--- a/kratos/includes/constitutive_law.h
+++ b/kratos/includes/constitutive_law.h
@@ -81,8 +81,8 @@ public:
         RETURN_ON_RIGHT_EDGE    = 5,
         RETURN_ON_CORNER        = 6,
         RETURN_ON_APEX          = 7,
-        RETURN_FAILED           = -1,
-        RETURN_INVALID          = -2,
+        RETURN_FAILED           = 99, // 100-1 // do that because char is unsigned char with target=aarch64-none-linux-android24
+        RETURN_INVALID          = 98, // 100-2,
     };
 
     /**


### PR DESCRIPTION
When compiling on Android studio for Armv8 platform, the char is assumed unsigned. Therefore negative value is not accepted.